### PR TITLE
New seed nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -98,6 +98,8 @@ public:
 
         vSeeds.push_back(CDNSSeedData("nodes.docrypto.com","quan.nodes.docrypto.com"));
         vSeeds.push_back(CDNSSeedData("quantis-coin.io","quantis-coin.io"));
+        vSeeds.push_back(CDNSSeedData("quantis.syshost.io","quantis.syshost.io"));
+        vSeeds.push_back(CDNSSeedData("backup.syshost.io","backup.syshost.io"));
 
         convertSeeds(vFixedSeeds, pnSeed, ARRAYLEN(pnSeed), nDefaultPort);
 


### PR DESCRIPTION
Right now none of the initial seednodes are working, forcing everyone to add addip's into their quantis.conf.

I've added two seednodes on my own domain (quantis.syshost.io and backup.syshost.io) pointing to 80.211.152.68 & 107.173.171.154 which are known, working nodes.